### PR TITLE
Adding synthesize for different CSAnimation values to use animation fram...

### DIFF
--- a/CanvasLibrary/CSAnimationView.m
+++ b/CanvasLibrary/CSAnimationView.m
@@ -10,6 +10,8 @@
 
 @implementation CSAnimationView
 
+@synthesize delay, duration, type;
+
 - (void)awakeFromNib {
     if (self.type && self.duration && ! self.pauseAnimationOnAwake) {
         [self startCanvasAnimation];


### PR DESCRIPTION
If you want multiple different animations and you want to choose which animation to use at runtime then you will need access to these values outside of the storyboard. This will allow you to do things like this:

``` c
self.errorMessageView.delay = 0;
self.errorMessageView.duration = 0.5;
self.errorMessageView.type = CSAnimationTypeShake;

[self.errorMessageView startCanvasAnimation];
```

And still perform the same animations you would if you were specifying them in the storyboard.
