### PR TITLE
Clip toolbar bounds to prevent border on blurred view

### DIFF
--- a/CanvasLibrary/CSBlurView.m
+++ b/CanvasLibrary/CSBlurView.m
@@ -25,6 +25,7 @@
     toolbar.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     toolbar.barTintColor = view.backgroundColor;
     toolbar.barStyle = barStyle;
+    toolbar.clipsToBounds = YES;
     [view insertSubview:toolbar atIndex:0];
 }
 


### PR DESCRIPTION
When using CSBlurView, I was seeing a toolbar border at the top of my view like the one in this question: http://stackoverflow.com/questions/9438864/how-can-i-remove-the-top-border-on-uitoolbar. Clipping the toolbar fixes the issue.
